### PR TITLE
Declare return types to be compatible with composer 2.7+

### DIFF
--- a/src/Command/UpstreamRequireCommand.php
+++ b/src/Command/UpstreamRequireCommand.php
@@ -18,7 +18,7 @@ class UpstreamRequireCommand extends RequireCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         parent::configure();
         $this
@@ -31,7 +31,7 @@ class UpstreamRequireCommand extends RequireCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         $composer = $this->getComposer();

--- a/src/Command/UpstreamUpdateDependenciesCommand.php
+++ b/src/Command/UpstreamUpdateDependenciesCommand.php
@@ -18,7 +18,7 @@ class UpstreamUpdateDependenciesCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('upstream:update-dependencies')
@@ -30,7 +30,7 @@ class UpstreamUpdateDependenciesCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         $composer = $this->getComposer();


### PR DESCRIPTION
If you see `Fatal error: Declaration of {some-class}::execute(...) must be compatible with Composer\Command\SomeCommand::execute(): int` then whatever code is extending a Composer command needs to be updated to also add the int return type, see https://github.com/composer/composer/issues/11843 for more details.

More info:
- https://github.com/composer/composer/releases/tag/2.7.0
- https://github.com/composer/composer/issues/11843