### PR TITLE
Set return type for execute functions.

### DIFF
--- a/src/Command/UpstreamRequireCommand.php
+++ b/src/Command/UpstreamRequireCommand.php
@@ -31,7 +31,7 @@ class UpstreamRequireCommand extends RequireCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         $composer = $this->getComposer();

--- a/src/Command/UpstreamUpdateDependenciesCommand.php
+++ b/src/Command/UpstreamUpdateDependenciesCommand.php
@@ -30,7 +30,7 @@ class UpstreamUpdateDependenciesCommand extends BaseCommand
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = $this->getIO();
         $composer = $this->getComposer();


### PR DESCRIPTION
It is ok to have a return type when the parent doesn't specify one so this should not break BC. Aiming for a patch release.