### PR TITLE
Ensure the locked composer.json is up to date with composer.lock

### DIFF
--- a/src/Command/UpstreamRequireCommand.php
+++ b/src/Command/UpstreamRequireCommand.php
@@ -69,6 +69,11 @@ class UpstreamRequireCommand extends RequireCommand
             throw new \RuntimeException("Could not add dependency to upstream.");
         }
 
+        // Update/generate the locked/composer.json file, unless --no-update was provided.
+        if (!$addNoUpdate) {
+          $this->generateLockedComposerJson($io);
+        }
+
         // @codingStandardsIgnoreLine
         $io->writeError('upstream-configuration/composer.json updated. Commit the upstream-configuration/composer.lock file if you wish to lock your upstream dependency versions in sites created from this upstream.');
         return $statusCode;


### PR DESCRIPTION
To keep the locked composer.json file in sync with composer.lock, it should be regenerated when new packages are added with `upstream:require` , unless the `--no-update` option is specified, in which case neither file is updated.

I've also added the ability to set the `--lock` option when running `upstream:update-dependencies` to ensure the locked composer.json file can be updated to match composer.lock without updating any packages.

This implements the option @marcaddeo recommended in #9.